### PR TITLE
Fixed typographical error, changed attemt to attempt in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ if you want to see stack traces then use TRACE.
 
 If you just want to dump the contents of a wallet to the
 console with no GUI interaction then you can pass it a file
-name, if you do this then it will not attemt to open any
+name, if you do this then it will not attempt to open any
 graphical user interface, it will just dump the wallet contents
 to stdout and exit. Note that the format of the dump is still
 subject to change, keep this in mind when writing a parser


### PR DESCRIPTION
@prof7bit, I've corrected a typographical error in the documentation of the [wallet-key-tool](https://github.com/prof7bit/wallet-key-tool) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
